### PR TITLE
Load Android Gradle Plugin conditionally

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,35 +8,35 @@ def computeVersionName() {
     return json.version
 }
 
-def DEF_BUILD_TOOLS_VERSION = '27.0.3'
-def DEF_MIN_SDK_VERSION     = 16
-def DEF_COMPILE_SDK_VERSION = 27
-def DEF_TARGET_SDK_VERSION  = 27
-
-def _buildToolsVersion  = rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEF_BUILD_TOOLS_VERSION
-def _minSdkVersion      = rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : DEF_MIN_SDK_VERSION
-def _compileSdkVersion  = rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEF_COMPILE_SDK_VERSION
-def _targetSdkVersion   = rootProject.hasProperty('targetSdkVersion')  ? rootProject.targetSdkVersion  : DEF_TARGET_SDK_VERSION
+def safeExtGet = {prop, fallback ->
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
 buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
+    if (project == rootProject) {
+        repositories {
+            google()
+            jcenter()
+        }
+
+        dependencies {
+            classpath("com.android.tools.build:gradle:3.5.3")
+        }
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion _compileSdkVersion
-    buildToolsVersion _buildToolsVersion
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
     defaultConfig {
-        minSdkVersion _minSdkVersion
-        targetSdkVersion _targetSdkVersion
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 16)
         versionCode 1
         versionName computeVersionName()
     }


### PR DESCRIPTION
Also, shorten root project gradle config loading and upgrade default versions to match with RN v61+

This wraps the Android Gradle plugin dependency in the buildscripts section of android/build.gradle in a conditional:

```
if (project == rootProject) {
    // ... (dependency here)
}
```

The Android Gradle plugin is only required when opening the project stand-alone, not when it is included as a dependency. By doing this, the project opens correctly in Android Studio, and it can also be consumed as a native module dependency from an application project without affecting the app project (avoiding unnecessary downloads/conflicts/etc).

for more info, you can refer to [this thread](https://github.com/facebook/react-native/pull/25569) and especially [this comment.](https://github.com/facebook/react-native/pull/25569#issuecomment-532504277)