### PR TITLE
Temporary fix for Xiaomi devices

### DIFF
--- a/android/src/main/java/com/github/amarcruz/rnshortcutbadge/RNShortcutBadgeModule.java
+++ b/android/src/main/java/com/github/amarcruz/rnshortcutbadge/RNShortcutBadgeModule.java
@@ -143,8 +143,8 @@ public class RNShortcutBadgeModule extends ReactContextBaseJavaModule {
 
         Notification.Builder builder = new Notification.Builder(context)
                 .setContentTitle("")
-                .setContentText("");
-        //.setSmallIcon(R.drawable.ic_launcher);
+                .setContentText("")
+                .setSmallIcon(R.drawable.ic_launcher);
         Notification notification = builder.build();
         ShortcutBadger.applyNotification(context, notification, count);
         mNotificationManager.notify(mNotificationId, notification);

--- a/android/src/main/res/drawable/ic_launcher.xml
+++ b/android/src/main/res/drawable/ic_launcher.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+</selector>


### PR DESCRIPTION
This fix prevents Xiaomi devices from breaking, but the number of notifications is not show on the app icon.